### PR TITLE
updateTick correction

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -118,7 +118,7 @@ module.exports = {
 					title: "Update tick",
 					description: "Interval between state update (ms)",
 					type: "number",
-					default: 3000
+					default: 15e3
 				}
 			},
 			order: 1


### PR DESCRIPTION
Corrected the updateTick, Discord RichPresence can't get updated below 15 seconds each time
- Also according to a correct issue being opened, this package takes some serious usage of our machine

As you're saying this package got some settings, the settings are good but not the interval settings.
You can't make the interval to 3 seconds by default without knowing it will take huge part of machine's usage and it's wrong according to Discord's API
Why not setting it to 15 seconds by default which:
- Is the correct thing to do when it comes to not spamming the API
- not making the interval take such a big part of machine's usage