### PR TITLE
Add option for CustomProjectName

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,39 +15,51 @@
       "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
     },
     "discord-rpc": {
-      "version": "3.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/discord-rpc/-/discord-rpc-3.0.0-beta.2.tgz",
-      "integrity": "sha512-rPEQ88mybc8PcYdO+gnyQ9M2vLHhFxUj1dKaTaLy1sTjNkgL2YzSPVUfEbmxYInP4umLjSbs3zMI7wJMK8ZKPg==",
+      "version": "3.0.0-beta.10",
+      "resolved": "https://registry.npmjs.org/discord-rpc/-/discord-rpc-3.0.0-beta.10.tgz",
+      "integrity": "sha512-b0G6O0WJkxoLQSopyNRqByXCrpBL68HXPMULVZXLjRgj+sStwOmbABM+HwBDJWF6s/uhkB/+cAgq+19x4w0SPA==",
       "requires": {
-        "discord.js": "github:hydrabolt/discord.js#5cd42695aeb974e998d4b220cba1c27b30a55628",
+        "discord.js": "github:discordjs/discord.js#8551b8936ce84a5b8c487d3ec9d55f38a5cd4c50",
         "snekfetch": "3.5.8"
+      },
+      "dependencies": {
+        "discord.js": {
+          "version": "github:discordjs/discord.js#8551b8936ce84a5b8c487d3ec9d55f38a5cd4c50",
+          "requires": {
+            "pako": "1.0.6",
+            "prism-media": "0.2.1",
+            "snekfetch": "3.6.4",
+            "tweetnacl": "1.0.0",
+            "ws": "4.1.0"
+          },
+          "dependencies": {
+            "snekfetch": {
+              "version": "3.6.4",
+              "resolved": "https://registry.npmjs.org/snekfetch/-/snekfetch-3.6.4.tgz",
+              "integrity": "sha512-NjxjITIj04Ffqid5lqr7XdgwM7X61c/Dns073Ly170bPQHLm6jkmelye/eglS++1nfTWktpP6Y2bFXjdPlQqdw=="
+            }
+          }
+        },
+        "prism-media": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-0.2.1.tgz",
+          "integrity": "sha512-Kfp1+6gzjY6X8mqKHa6D3brX+BtMUPFwzAkz4zgtVPgbkA2XxhITROdfQXVurU4fuJsylFRwqo7ciQlQCm9hAw=="
+        },
+        "ws": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
+          "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
+          "requires": {
+            "async-limiter": "1.0.0",
+            "safe-buffer": "5.1.1"
+          }
+        }
       }
-    },
-    "discord.js": {
-      "version": "github:hydrabolt/discord.js#5cd42695aeb974e998d4b220cba1c27b30a55628",
-      "requires": {
-        "long": "3.2.0",
-        "pako": "1.0.6",
-        "prism-media": "0.0.2",
-        "snekfetch": "3.5.8",
-        "tweetnacl": "1.0.0",
-        "ws": "3.3.1"
-      }
-    },
-    "long": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
-      "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
     },
     "pako": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
       "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg=="
-    },
-    "prism-media": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-0.0.2.tgz",
-      "integrity": "sha512-L6yc8P5NVG35ivzvfI7bcTYzqFV+K8gTfX9YaJbmIFfMXTs71RMnAupvTQPTCteGsiOy9QcNLkQyWjAafY/hCQ=="
     },
     "safe-buffer": {
       "version": "5.1.1",
@@ -63,21 +75,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
       "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
-    },
-    "ultron": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.0.tgz",
-      "integrity": "sha1-sHoualQagV/Go0zNRTO67DB8qGQ="
-    },
-    "ws": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.1.tgz",
-      "integrity": "sha512-8A/uRMnQy8KCQsmep1m7Bk+z/+LIkeF7w+TDMLtX1iZm5Hq9HsUDmgFGaW1ACW5Cj0b2Qo7wCvRhYN2ErUVp/A==",
-      "requires": {
-        "async-limiter": "1.0.0",
-        "safe-buffer": "5.1.1",
-        "ultron": "1.1.0"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
   },
   "dependencies": {
     "bluebird": "^3.5.1",
-    "discord-rpc": "^3.0.0-beta.2"
+    "discord-rpc": "^3.0.0-beta.10"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -63,7 +63,8 @@ const createLoop = () => {
 		if (onlineEditor && onlineEditor.buffer && onlineEditor.buffer.file) {
 			const projectPath = atom.project.relativizePath(onlineEditor.buffer.file.path)[0];
 
-			if(!projectPath) projectName = null;
+			if (customProject.value != null) projectName = customProject.value;
+			else if(!projectPath) projectName = null;
 			else projectName = path.basename(projectPath);
 		} else projectName = null;
 	};
@@ -118,6 +119,7 @@ module.exports = {
 			description: "",
 			type: "object",
 			properties: {
+
 				sendSmallImage: {
 					title: "Display small Atom logo",
 					description: "",
@@ -144,6 +146,14 @@ module.exports = {
 					description: "",
 					type: "boolean",
 					default: false
+				},
+
+
+				customProject: {
+					title: "Use Custom Project Name",
+					description: "Set your custom project name :P",
+					type: "string",
+					default: null
 				},
 
 				updateTick: {

--- a/src/index.js
+++ b/src/index.js
@@ -63,7 +63,14 @@ const createLoop = () => {
 		if (onlineEditor && onlineEditor.buffer && onlineEditor.buffer.file) {
 			const projectPath = atom.project.relativizePath(onlineEditor.buffer.file.path)[0];
 
-			if (customProject.value != null) projectName = customProject.value;
+			var projectCName = atom.config.get('atom-discord.privacy.customProject');
+
+			if (projectCName != "null")
+			{
+				projectName = projectCName;
+				console.log("ProjectName: " + projectName);
+				updateData();
+			}
 			else if(!projectPath) projectName = null;
 			else projectName = path.basename(projectPath);
 		} else projectName = null;
@@ -146,14 +153,6 @@ module.exports = {
 					description: "",
 					type: "boolean",
 					default: false
-				},
-
-
-				customProject: {
-					title: "Use Custom Project Name",
-					description: "Set your custom project name :P",
-					type: "string",
-					default: null
 				},
 
 				updateTick: {
@@ -286,6 +285,13 @@ module.exports = {
 			description: "Select things to integrate",
 			type: "object",
 			properties: {
+				sendLargeImage: {
+					title: "Display large file type image",
+					description: "",
+					type: "boolean",
+					default: true
+				},
+
 				sendFilename: {
 					title: "Send File name",
 					description: "Integrate file name.",
@@ -295,9 +301,16 @@ module.exports = {
 
 				sendProject: {
 					title: "Send Project name",
-					description: "Integrate project name.",
+					description: "Integrate project name.  If you are using customProject set that **True**.",
 					type: "boolean",
 					default: true
+				},
+
+				customProject: {
+					title: "Use Custom Project Name",
+					description: "Set your custom project name :P\nIf you want your real ProjectName set it **null**",
+					type: "string",
+					default: "null"
 				},
 
 				sendFileType: {


### PR DESCRIPTION
Adding option to use your own ProjectName in case you don't like it..

You know that when you are editing files directly from FileZilla:
![image](https://user-images.githubusercontent.com/19608120/38767985-c8dbede0-3ff4-11e8-80c7-58f6cf855e89.png)

Now just put your Project Name here:
![image](https://user-images.githubusercontent.com/19608120/38767997-0cf36972-3ff5-11e8-9bcc-a1dcc5c30413.png)

And then you will see that:
![image](https://user-images.githubusercontent.com/19608120/38768003-2a6876be-3ff5-11e8-9759-d487245a5b73.png)
Your ProjectName is that which you set, instead of stupid FileZilla Temp folder :D 
